### PR TITLE
DJAN-45, DJAN-9: Make Analytics (ua) configurable in webapps 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config/*.csv
 *.DS_Store
 .idea
 cspace_django_site/secret_key.py
+cspace_django_site/extra_settings.py

--- a/cspace_django_site/extra_dev.py
+++ b/cspace_django_site/extra_dev.py
@@ -1,0 +1,19 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_PARENT_DIR = os.path.dirname(BASE_DIR)
+LOGS_DIR = BASE_PARENT_DIR + os.sep + 'logs'
+PROJECT_NAME = os.path.basename(BASE_PARENT_DIR)
+GOOGLE_ANALYTICS = 0
+
+CACHES = {
+   'default': {
+       'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+       'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
+       #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
+       'CULL_FREQUENCY': 100000,
+       'OPTIONS': {
+           'MAX_ENTRIES': 1000000
+       }
+   }
+}

--- a/cspace_django_site/extra_prod.py
+++ b/cspace_django_site/extra_prod.py
@@ -1,0 +1,19 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_PARENT_DIR = os.path.dirname(BASE_DIR)
+LOGS_DIR = BASE_PARENT_DIR + os.sep + 'logs'
+PROJECT_NAME = os.path.basename(BASE_PARENT_DIR)
+GOOGLE_ANALYTICS = 1
+
+CACHES = {
+   'default': {
+       'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+       'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
+       #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
+       'CULL_FREQUENCY': 100000,
+       'OPTIONS': {
+           'MAX_ENTRIES': 1000000
+       }
+   }
+}

--- a/cspace_django_site/extra_pycharm.py
+++ b/cspace_django_site/extra_pycharm.py
@@ -1,0 +1,17 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_PARENT_DIR = os.path.dirname(BASE_DIR)
+LOGS_DIR = BASE_PARENT_DIR + os.sep + 'logs'
+PROJECT_NAME = os.path.basename(BASE_PARENT_DIR)
+
+CACHES = {
+   'default': {
+       'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+       'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
+       'CULL_FREQUENCY': 100000,
+       'OPTIONS': {
+           'MAX_ENTRIES': 1000000
+       }
+   }
+}

--- a/cspace_django_site/settings.py
+++ b/cspace_django_site/settings.py
@@ -11,7 +11,7 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 import django.conf.global_settings as DEFAULT_SETTINGS  # http://stackoverflow.com/a/15446953/1763984
-GOOGLE_ANALYTICS = False
+GOOGLE_ANALYTICS = -1
 TEMPLATE_CONTEXT_PROCESSORS = DEFAULT_SETTINGS.TEMPLATE_CONTEXT_PROCESSORS + (
     'django.core.context_processors.request',
     'cspace_django_site.context_processors.settings',
@@ -43,17 +43,17 @@ REST_FRAMEWORK = {
     ]
 }
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
-        #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
-        'CULL_FREQUENCY': 100000,
-        'OPTIONS': {
-            'MAX_ENTRIES': 1000000
-        }
-    }
-}
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+#         'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
+#         #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
+#         'CULL_FREQUENCY': 100000,
+#         'OPTIONS': {
+#             'MAX_ENTRIES': 1000000
+#         }
+#     }
+# }
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
@@ -286,4 +286,7 @@ except ImportError:
     generate_secret_key(os.path.join(SETTINGS_DIR, 'secret_key.py'))
     from secret_key import *
 
-#secret_KEY=os.environ.get('secret_KEY')
+try:
+	from extra_settings import *
+except ImportError, exp:
+	pass

--- a/cspace_django_site/static/cspace_django_site/js/enable.js
+++ b/cspace_django_site/static/cspace_django_site/js/enable.js
@@ -1,0 +1,13 @@
+function enablega(method, id, obj, googleAnalytics) {
+    var tracker = '';
+    if (googleAnalytics == 1) {
+         tracker = 'prodtracker.';
+    } else if (googleAnalytics == -1) {
+         tracker = 'uitracker.';
+    }
+    if (typeof obj === undefined) {
+         return ga(tracker + method, id);
+    } else {
+        return ga(tracker + method, id, obj);
+    }
+}

--- a/cspace_django_site/static/cspace_django_site/js/ua.js
+++ b/cspace_django_site/static/cspace_django_site/js/ua.js
@@ -1,10 +1,15 @@
 /* universal analytics snippet */
 
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+ (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+ (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+ })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-54952024-10', 'auto');
-  ga('send', 'pageview');
+/* Default tracking object for webapps-dev.cspace */
+ ga('create', 'UA-54952024-6', 'none');
 
+/* Tracking object for pahma.cspace.berkeley.edu */
+ ga('create', 'UA-54952024-10', 'none', {'name': 'uitracker'});
+
+/* Tracking object for webapps.cspace.berkeley.edu */
+ ga('create', 'UA-54952024-5', 'none', {'name': 'prodtracker'});

--- a/cspace_django_site/templates/cspace_django_site/base.html
+++ b/cspace_django_site/templates/cspace_django_site/base.html
@@ -6,10 +6,13 @@
     
     {% block scripts %}{% endblock %}
 
-    <!--  if googleAnalytics  -->
+    <script type="text/javascript" src="{% static "cspace_django_site/js/enable.js" %}"></script>
     <script type="text/javascript" src="{% static "cspace_django_site/js/ua.js" %}"></script>
-    <!--  endif  -->
-    
+    <script type="text/javascript">
+        var googleAnalytics = {{ googleAnalytics }};
+        enablega('send', 'pageview', undefined, googleAnalytics);
+    </script>
+
     <link rel="stylesheet" type="text/css" href="{% static "cspace_django_site/css/reset.css" %}" />
     <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "cspace_django_site/css/base.css" %}{% endblock %}" />
     <!--[if lte IE 7]><link rel="stylesheet" type="text/css" href="{% block stylesheet_ie %}{% static "admin/css/ie.css" %}{% endblock %}" /><![endif]-->

--- a/search/static/search/js/PublicSearch.js
+++ b/search/static/search/js/PublicSearch.js
@@ -220,7 +220,7 @@ $(document).ready(function () {
                     display: "block"
                 });
 
-                ga('send', 'pageview', { 'page': '/search' });
+                enablega('send', 'pageview', { 'page': '/search' }, googleAnalytics);
             });
         }
     };
@@ -250,12 +250,12 @@ $(document).ready(function () {
             $.post("../statistics/", formData).done(function (data) {
                 $('#statsresults').html(data);
             });
-            ga('send', 'pageview', { 'page': '/summarize/display' });
+            enablega('send', 'pageview', { 'page': '/summarize/display' }, googleAnalytics);
 //        } else if ($(this).attr('id') == 'downloadstats') {
 //            $.post("../statistics/", formData).done(function (data) {
 //                alert( "success" );
 //            });
-//            ga('send', 'pageview', { 'page': '/summarize/download' });
+//            enablega('send', 'pageview', { 'page': '/summarize/download' }, googleAnalytics);
         }
 
         $('#waitingImage').css({
@@ -264,7 +264,7 @@ $(document).ready(function () {
 
         $('#statsListing').tablesorter({theme: 'blue'});
 
-        ga('send', 'pageview', { 'page': '/statistics' });
+        enablega('send', 'pageview', { 'page': '/statistics' }, googleAnalytics);
     });
 
     $(document).on('click', '.map-item', function () {
@@ -278,7 +278,7 @@ $(document).ready(function () {
             '<small><a target="_map" href="https://maps.google.com/maps/i?q=loc:'+marker+'&amp;source=embed">Larger Map</a>'+
             '</small></div>');
             Elem.slideDown();
-            ga('send', 'pageview', { 'page': '/map/inline' });
+            enablega('send', 'pageview', { 'page': '/map/inline' }, googleAnalytics);
         }
         else {
             Elem.slideUp();
@@ -303,7 +303,6 @@ $(document).ready(function () {
                 }
             }
         }
-
         var formData = getFormData('#search');
         // TODO: CURRENTLY DEFAULT TO SEARCH-LIST BUT SHOULD HAVE A PERSISTENT DISPLAY TYPE? CURRENTLY DOESN'T ON DEV
         formData['search-list'] = '';
@@ -323,9 +322,8 @@ $(document).ready(function () {
             });
 
             $('#tabs').tabs({ active: 1 });
-            ga('send', 'pageview', { 'page': '/search/refine' });
+            enablega('send', 'pageview', { 'page': '/search/refine' }, googleAnalytics);
         });
-
     });
 
     $(document).on('click', '#map-bmapper, #map-google', function () {
@@ -336,12 +334,12 @@ $(document).ready(function () {
             $.post("../bmapper/", formData).done(function (data) {
                 window.open(data, '_blank');
             });
-            ga('send', 'pageview', { 'page': '/map/bmapper' });
+            enablega('send', 'pageview', { 'page': '/map/bmapper' }, googleAnalytics);
         } else if ($(this).attr('id') == 'map-google') {
             $.post("../gmapper/", formData).done(function (data) {
                 $('#maps').html(data);
             });
-            ga('send', 'pageview', { 'page': '/map/google' });
+            enablega('send', 'pageview', { 'page': '/map/google' }, googleAnalytics);
         }
     });
 // we need to make sure this gets done in the event the page is created anew (e.g. via a pasted URL)

--- a/search/templates/search.html
+++ b/search/templates/search.html
@@ -12,6 +12,10 @@
     <script type="text/javascript" src="{% static "cspace_django_site/js/jquery-1.10.0.min.js" %}"></script>
     <script type="text/javascript" src="{% static "cspace_django_site/js/jquery-ui-1.10.3.custom.min.js" %}"></script>
     <script type="text/javascript" src="{% static "search/js/PublicSearch.js" %}"></script>
+    <script type="text/javascript">
+        var googleAnalytics = {{ googleAnalytics }};
+        document.write(googleAnalytics);
+    </script>
     <script type="text/javascript" src="{% static "search/js/jquery.tablesorter.min.js" %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
Commit includes the following modifications:
For handling multiple settings that differ based on deployment 
0. added extra_prod, extra_dev, and extra_pycharm Python files e/ with server specific settings 
1. added extra_settings.py to .gitignore; as part of deployment, we copy one of the files in 0. to extra_settings.py
2. settings.py has try block to read in extra_settings.py or pass if extra_settings.py is not found; commented out (can eventually remove) CACHES

For Analytics ('ua') on multiple servers:
0. ua.js changed to create 3 different tracker objects: one each for dev (default/nameless), prod, regular ui
1. enable.js contains custom enablega method that specifies the tracker object in the call to ga
2. added var googleAnalytics = {{googleAnalytics}} snippets to cspace_django_site/templates/cspace_django_site/base.html and search/search.html, setting the context variable to a variable callable in the js files
3. publicsearch.js calls enablega now and passes in the googleAnalytics variable from 2.

