### PR TITLE
DJAN-45: removed mainly local testing snippets from ua.js and settings.py

### DIFF
--- a/cspace_django_site/extra_dev.py
+++ b/cspace_django_site/extra_dev.py
@@ -10,7 +10,6 @@ CACHES = {
    'default': {
        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
        'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
-       #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
        'CULL_FREQUENCY': 100000,
        'OPTIONS': {
            'MAX_ENTRIES': 1000000

--- a/cspace_django_site/extra_prod.py
+++ b/cspace_django_site/extra_prod.py
@@ -10,7 +10,6 @@ CACHES = {
    'default': {
        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
        'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
-       #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
        'CULL_FREQUENCY': 100000,
        'OPTIONS': {
            'MAX_ENTRIES': 1000000

--- a/cspace_django_site/settings.py
+++ b/cspace_django_site/settings.py
@@ -43,18 +43,6 @@ REST_FRAMEWORK = {
     ]
 }
 
-# CACHES = {
-#     'default': {
-#         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-#         'LOCATION': '/home/app_webapps/cache/' + PROJECT_NAME + '/images',
-#         #'LOCATION': '/tmp/' + PROJECT_NAME + '/images',
-#         'CULL_FREQUENCY': 100000,
-#         'OPTIONS': {
-#             'MAX_ENTRIES': 1000000
-#         }
-#     }
-# }
-
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = []

--- a/cspace_django_site/static/cspace_django_site/js/ua.js
+++ b/cspace_django_site/static/cspace_django_site/js/ua.js
@@ -6,10 +6,10 @@
  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 /* Default tracking object for webapps-dev.cspace */
- ga('create', 'UA-54952024-6', 'none');
+ ga('create', 'UA-54952024-6', 'auto');
 
 /* Tracking object for pahma.cspace.berkeley.edu */
- ga('create', 'UA-54952024-10', 'none', {'name': 'uitracker'});
+ ga('create', 'UA-54952024-10', 'auto', {'name': 'uitracker'});
 
 /* Tracking object for webapps.cspace.berkeley.edu */
- ga('create', 'UA-54952024-5', 'none', {'name': 'prodtracker'});
+ ga('create', 'UA-54952024-5', 'auto', {'name': 'prodtracker'});

--- a/search/templates/search.html
+++ b/search/templates/search.html
@@ -14,7 +14,6 @@
     <script type="text/javascript" src="{% static "search/js/PublicSearch.js" %}"></script>
     <script type="text/javascript">
         var googleAnalytics = {{ googleAnalytics }};
-        document.write(googleAnalytics);
     </script>
     <script type="text/javascript" src="{% static "search/js/jquery.tablesorter.min.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
Includes removing commented out CACHES in settings.py; setting cookieDomain in ga('create',...) to auto instead of none (because none should be used mainly to test on localhost); remove document.write(googleAnalytics) from search.html since that was used for testing (i.e. checking values of googleAnalytics).